### PR TITLE
Add user profile and delete endpoints

### DIFF
--- a/models/Utilisateur.js
+++ b/models/Utilisateur.js
@@ -25,6 +25,11 @@ const utilisateurSchema = new mongoose.Schema({
     isAdmin: {
         type: Boolean,
         default: false,
+    },
+    securityKey: {
+        type: String,
+        required: true,
+        unique: true
     }
 });
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,8 @@
         "dotenv": "^16.5.0",
         "express": "^5.1.0",
         "jsonwebtoken": "^9.0.2",
-        "mongoose": "^8.13.2"
+        "mongoose": "^8.13.2",
+        "uuid": "^11.1.0"
       },
       "devDependencies": {
         "nodemon": "^3.1.9"
@@ -1476,6 +1477,19 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/uuid": {
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.0.tgz",
+      "integrity": "sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/esm/bin/uuid"
       }
     },
     "node_modules/vary": {

--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
     "dotenv": "^16.5.0",
     "express": "^5.1.0",
     "jsonwebtoken": "^9.0.2",
-    "mongoose": "^8.13.2"
+    "mongoose": "^8.13.2",
+    "uuid": "^11.1.0"
   },
   "devDependencies": {
     "nodemon": "^3.1.9"

--- a/routes/notes.js
+++ b/routes/notes.js
@@ -126,7 +126,7 @@ router.put('/:id', auth, async (req, res) => {
         }
 
         if (typeof req.body.note === "number") {
-            note.note = req.body.note;
+            note.note = Math.round(req.body.note * 100) / 100;
         }
 
         await note.save();

--- a/test.http
+++ b/test.http
@@ -47,3 +47,11 @@ Authorization: Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6IjY3ZmZmNDVmZ
   "coefficient": 1.5
 }
 
+### 👤 PROFIL UTILISATEUR
+GET http://localhost:5000/api/utilisateurs/me
+Authorization: Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6IjY3ZmZmNDVmZDFiYWZmMjA2ODU1OTY3YiIsImlzQWRtaW4iOmZhbHNlLCJpYXQiOjE3NDQ4Mjc5NjIsImV4cCI6MTc0NDgzNTE2Mn0.PT41NjH1vLIjLI2mn-jqmTaq8aEaPNSeTcP2TW2DYt0
+
+### ❌ SUPPRIMER MON COMPTE
+DELETE http://localhost:5000/api/utilisateurs/me
+Authorization: Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6IjY3ZmZmNDVmZDFiYWZmMjA2ODU1OTY3YiIsImlzQWRtaW4iOmZhbHNlLCJpYXQiOjE3NDQ4Mjc5NjIsImV4cCI6MTc0NDgzNTE2Mn0.PT41NjH1vLIjLI2mn-jqmTaq8aEaPNSeTcP2TW2DYt0
+


### PR DESCRIPTION
## Summary
- add uuid dependency
- store a per-user security key
- validate email during signup
- return security key on login
- add profile and delete account endpoints
- round note values to two decimals
- update demo `test.http`

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6846cd4c3fa0832392318da8d069d43a